### PR TITLE
Add excel-based recipe training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,19 @@ step influences the prediction or etch depth.
 
 ## Files
 
-- `attention_model.py` – defines the dataset loader and the model.
-- `requirements.txt` – Python dependencies.
+- `attention_model.py` – basic attention model and utilities. Includes an
+  example for loading recipe data from an Excel workbook where each sheet
+  corresponds to a different recipe structure.
+- `etch_rate_model.py` – extended example with film scheme and layout embeddings.
+- `requirements.txt` – Python dependencies (including `openpyxl` for Excel
+  support).
 
 ## Usage
 
 Install the dependencies and adapt the dataset loader in `attention_model.py`
-to your CSV or database. The script includes a simple training loop example.
+to your CSV, database, or Excel workbook. The script includes a simple
+training loop example that demonstrates loading multiple sheets from an Excel
+file.
 
 ```bash
 pip install -r requirements.txt

--- a/attention_model.py
+++ b/attention_model.py
@@ -62,6 +62,52 @@ class RecipeDataset(Dataset):
         return torch.from_numpy(step_types), torch.from_numpy(knobs), torch.from_numpy(targets)
 
 
+class ExcelRecipeDataset(Dataset):
+    """Load recipe data from an Excel workbook with multiple sheets."""
+
+    def __init__(self, excel_path: str):
+        sheets = pd.read_excel(excel_path, sheet_name=None)
+        frames = []
+        max_len = 0
+        for df in sheets.values():
+            step_cols = [c for c in df.columns if c.startswith("step_type_")]
+            knob_cols = [c for c in df.columns if c.startswith("knob_")]
+            max_len = max(max_len, len(step_cols))
+            frames.append(df)
+
+        all_step_cols = [f"step_type_{i}" for i in range(max_len)]
+        all_knob_cols = [f"knob_{i}" for i in range(max_len)]
+        for df in frames:
+            for col in all_step_cols:
+                if col not in df.columns:
+                    df[col] = 0
+            for col in all_knob_cols:
+                if col not in df.columns:
+                    df[col] = 0.0
+            df.reindex(columns=all_step_cols + all_knob_cols, fill_value=0)
+
+        self.data = pd.concat(frames, ignore_index=True)
+        self.seq_len = max_len
+        self.step_cols = all_step_cols
+        self.knob_cols = all_knob_cols
+        self.target_cols = [c for c in self.data.columns if c.startswith("target_")]
+        self.num_step_types = int(self.data[self.step_cols].max().max()) + 1
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        row = self.data.iloc[idx]
+        step_types = row[self.step_cols].to_numpy(dtype=np.int64)
+        knobs = row[self.knob_cols].to_numpy(dtype=np.float32)
+        targets = row[self.target_cols].to_numpy(dtype=np.float32)
+        return (
+            torch.from_numpy(step_types),
+            torch.from_numpy(knobs),
+            torch.from_numpy(targets),
+        )
+
+
 def _generate_example_csv(path: str, num_samples=100, seq_len=4, num_targets=2, num_step_types=5):
     rng = np.random.default_rng(0)
     data = {}
@@ -71,6 +117,30 @@ def _generate_example_csv(path: str, num_samples=100, seq_len=4, num_targets=2, 
     for t in range(num_targets):
         data[f"target_{t}"] = rng.random(size=num_samples)
     pd.DataFrame(data).to_csv(path, index=False)
+
+
+def _generate_example_excel(path: str) -> None:
+    """Create a toy Excel workbook with two recipe structures."""
+    rng = np.random.default_rng(0)
+    # first sheet has 4 steps
+    data_a = {}
+    for i in range(4):
+        data_a[f"step_type_{i}"] = rng.integers(0, 5, size=50)
+        data_a[f"knob_{i}"] = rng.random(size=50)
+    data_a["target_0"] = rng.random(size=50)
+    df_a = pd.DataFrame(data_a)
+
+    # second sheet has 3 steps
+    data_b = {}
+    for i in range(3):
+        data_b[f"step_type_{i}"] = rng.integers(0, 5, size=50)
+        data_b[f"knob_{i}"] = rng.random(size=50)
+    data_b["target_0"] = rng.random(size=50)
+    df_b = pd.DataFrame(data_b)
+
+    with pd.ExcelWriter(path) as writer:
+        df_a.to_excel(writer, sheet_name="ME_SL1_SL2_DF", index=False)
+        df_b.to_excel(writer, sheet_name="ME_SL1_DF", index=False)
 
 
 class AttentionModel(nn.Module):
@@ -133,23 +203,6 @@ def step_importance(weights: torch.Tensor) -> torch.Tensor:
     if weights.dim() == 3:
         weights = weights.mean(0)
     return weights.mean(0)
-  
-    def __init__(self, num_step_types: int, d_model: int, nhead: int, num_targets: int):
-        super().__init__()
-        self.embedding = nn.Embedding(num_step_types, d_model)
-        self.knob_proj = nn.Linear(1, d_model)
-        encoder_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead)
-        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=2)
-        self.fc = nn.Linear(d_model, num_targets)
-
-    def forward(self, step_types: torch.Tensor, knobs: torch.Tensor):
-        # step_types: (B, L)
-        # knobs: (B, L)
-        emb = self.embedding(step_types) + self.knob_proj(knobs.unsqueeze(-1))
-        emb = emb.transpose(0, 1)  # (L, B, D)
-        enc = self.encoder(emb)
-        enc = enc.mean(dim=0)  # (B, D)
-        return self.fc(enc)
 
 
 def train_example():
@@ -164,7 +217,6 @@ def train_example():
 
 
     model = AttentionModel(num_step_types=num_step_types, d_model=32, nhead=4, num_targets=num_targets, seq_len=seq_len)
-    model = AttentionModel(num_step_types=num_step_types, d_model=32, nhead=4, num_targets=num_targets)
     optim = torch.optim.Adam(model.parameters(), lr=1e-3)
     loss_fn = nn.MSELoss()
 
@@ -189,5 +241,39 @@ def train_example():
     print("Step importance:", step_importance(attn))
 
 
+def train_excel_example():
+    excel_path = "recipes.xlsx"
+    _generate_example_excel(excel_path)
+    dataset = ExcelRecipeDataset(excel_path)
+    loader = DataLoader(dataset, batch_size=16, shuffle=True)
+
+    model = AttentionModel(
+        num_step_types=dataset.num_step_types,
+        d_model=32,
+        nhead=4,
+        num_targets=len(dataset.target_cols),
+        seq_len=dataset.seq_len,
+    )
+    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    model.train()
+    for epoch in range(5):
+        for step_types, knobs, targets in loader:
+            optim.zero_grad()
+            preds = model(step_types, knobs)
+            loss = loss_fn(preds, targets)
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1} loss: {loss.item():.4f}")
+
+    plot_positional_encoding(model.pos_encoder.pe[:dataset.seq_len])
+    step_types, knobs, _ = next(iter(loader))
+    attn = model.attention_heatmap(step_types[0], knobs[0])
+    plot_attention_heatmap(attn)
+    print("Step importance:", step_importance(attn))
+
+
 if __name__ == "__main__":
-    train_example()
+    train_excel_example()
+

--- a/etch_rate_model.py
+++ b/etch_rate_model.py
@@ -1,0 +1,148 @@
+import math
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+import pandas as pd
+import numpy as np
+
+from attention_model import PositionalEncoding
+
+
+class EtchRateDataset(Dataset):
+    """Dataset including film scheme/layout info and etch rate targets."""
+
+    def __init__(self, csv_path: str, seq_len: int):
+        self.data = pd.read_csv(csv_path)
+        self.seq_len = seq_len
+        self.step_cols = [f"step_type_{i}" for i in range(seq_len)]
+        self.knob_cols = [f"knob_{i}" for i in range(seq_len)]
+        self.scheme_col = "scheme_id"
+        self.layout_col = "layout_id"
+        self.target_cols = [c for c in self.data.columns if c.startswith("target_")]
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        row = self.data.iloc[idx]
+        step_types = row[self.step_cols].to_numpy(dtype=np.int64)
+        knobs = row[self.knob_cols].to_numpy(dtype=np.float32)
+        scheme = np.int64(row[self.scheme_col])
+        layout = np.int64(row[self.layout_col])
+        targets = row[self.target_cols].to_numpy(dtype=np.float32)
+        return (
+            torch.from_numpy(step_types),
+            torch.from_numpy(knobs),
+            torch.tensor(scheme),
+            torch.tensor(layout),
+            torch.from_numpy(targets),
+        )
+
+
+def _generate_example_csv(
+    path: str,
+    num_samples: int = 100,
+    seq_len: int = 4,
+    num_targets: int = 1,
+    num_step_types: int = 5,
+    num_schemes: int = 3,
+    num_layouts: int = 2,
+):
+    rng = np.random.default_rng(0)
+    data = {}
+    for i in range(seq_len):
+        data[f"step_type_{i}"] = rng.integers(0, num_step_types, size=num_samples)
+        data[f"knob_{i}"] = rng.random(size=num_samples)
+    data["scheme_id"] = rng.integers(0, num_schemes, size=num_samples)
+    data["layout_id"] = rng.integers(0, num_layouts, size=num_samples)
+    for t in range(num_targets):
+        data[f"target_{t}"] = rng.random(size=num_samples)
+    pd.DataFrame(data).to_csv(path, index=False)
+
+
+class EtchRateTransformer(nn.Module):
+    """Transformer model for etch rate prediction with scheme/layout embeddings."""
+
+    def __init__(
+        self,
+        num_step_types: int,
+        num_schemes: int,
+        num_layouts: int,
+        d_model: int,
+        nhead: int,
+        num_targets: int,
+        seq_len: int,
+    ):
+        super().__init__()
+        self.step_embed = nn.Embedding(num_step_types, d_model)
+        self.knob_proj = nn.Linear(1, d_model)
+        self.scheme_embed = nn.Embedding(num_schemes, d_model)
+        self.layout_embed = nn.Embedding(num_layouts, d_model)
+        self.pos_encoder = PositionalEncoding(d_model, max_len=seq_len)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model, nhead=nhead, batch_first=True
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=2)
+        self.fc = nn.Linear(d_model, num_targets)
+
+    def forward(
+        self,
+        step_types: torch.Tensor,
+        knobs: torch.Tensor,
+        scheme: torch.Tensor,
+        layout: torch.Tensor,
+    ) -> torch.Tensor:
+        step_emb = self.step_embed(step_types) + self.knob_proj(knobs.unsqueeze(-1))
+        scheme_emb = self.scheme_embed(scheme).unsqueeze(1)
+        layout_emb = self.layout_embed(layout).unsqueeze(1)
+        x = step_emb + scheme_emb + layout_emb
+        x = self.pos_encoder(x)
+        enc = self.encoder(x)
+        return self.fc(enc.mean(dim=1))
+
+
+def train_etch_rate_example():
+    csv_path = "etch_example.csv"
+    seq_len = 5
+    num_step_types = 6
+    num_schemes = 3
+    num_layouts = 2
+    num_targets = 1
+
+    _generate_example_csv(
+        csv_path,
+        num_samples=200,
+        seq_len=seq_len,
+        num_targets=num_targets,
+        num_step_types=num_step_types,
+        num_schemes=num_schemes,
+        num_layouts=num_layouts,
+    )
+    dataset = EtchRateDataset(csv_path, seq_len=seq_len)
+    loader = DataLoader(dataset, batch_size=16, shuffle=True)
+
+    model = EtchRateTransformer(
+        num_step_types=num_step_types,
+        num_schemes=num_schemes,
+        num_layouts=num_layouts,
+        d_model=32,
+        nhead=4,
+        num_targets=num_targets,
+        seq_len=seq_len,
+    )
+    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.MSELoss()
+
+    model.train()
+    for epoch in range(5):
+        for step_types, knobs, scheme, layout, targets in loader:
+            optim.zero_grad()
+            preds = model(step_types, knobs, scheme, layout)
+            loss = loss_fn(preds, targets)
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1} loss: {loss.item():.4f}")
+
+
+if __name__ == "__main__":
+    train_etch_rate_example()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 pandas
 numpy
 matplotlib
+openpyxl


### PR DESCRIPTION
## Summary
- support loading recipes from an Excel workbook via new `ExcelRecipeDataset`
- provide a training example that reads multiple sheets and feeds them to the transformer
- document Excel support and add `openpyxl` to requirements

## Testing
- `python -m py_compile etch_rate_model.py attention_model.py`