### PR TITLE
Refine training script and drop synthetic data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,22 @@
 # Transformer for Plasma Etching
 
-This project provides a minimal implementation of an attention-based model
-to learn the relationship between a plasma etching recipe and the resulting
-profile metrics. It is intended as a starting point for researchers who want
-to experiment with Transformer-like architectures on process control data.
-
-The code uses PyTorch and expects recipe steps and tuning knob values as input
-features. The model outputs predicted profile properties such as bamboo width
-or etch depth. The example also demonstrates basic explainability utilities
-like positional encoding and attention heatmaps so you can inspect how each
-step influences the prediction or etch depth.
-
+This project provides a minimal implementation of an attention-based model to learn how plasma etching recipes influence profile metrics. It relies on PyTorch and expects tuning knob values as inputs. Basic explainability utilities such as positional encoding and attention heatmaps are included so you can inspect which steps matter most.
 
 ## Files
 
-
-- `attention_model.py` – basic attention model and utilities. Includes an
-  example for loading recipe data from an Excel workbook where each sheet
-  corresponds to a different recipe structure.
+- `attention_model.py` – attention model and utilities for loading an Excel workbook where each sheet represents a recipe structure.
 - `etch_rate_model.py` – extended example with film scheme and layout embeddings.
-- `requirements.txt` – Python dependencies (including `openpyxl` for Excel
-  support).
-
-- `attention_model.py` – basic attention model and utilities.
-- `etch_rate_model.py` – extended example with film scheme and layout embeddings.
-- `requirements.txt` – Python dependencies.
+- `requirements.txt` – Python dependencies (includes `openpyxl` for Excel support).
 
 ## Usage
 
-Install the dependencies and adapt the dataset loader in `attention_model.py`
-to your CSV, database, or Excel workbook. The script includes a simple
-training loop example that demonstrates loading multiple sheets from an Excel
-file.
+Prepare an Excel workbook where each sheet defines a recipe. Columns starting with `X_` represent sequential step inputs and those beginning with `Y_` are targets. Install the dependencies and run training:
 
 ```bash
 pip install -r requirements.txt
-python attention_model.py
+python attention_model.py /path/to/recipes.xlsx --epochs 20
 ```
 
+If no workbook path is given, the script looks for `recipes.xlsx` in the current directory.
 
-
-Running the script expects an input CSV file in the format described in
-`attention_model.py`. It will display a heatmap of the positional encodings as
-well as the attention weights for an example recipe, giving a quick look at how
-steps interact.
-
-
-This repository does not include a dataset. You must provide your own
-data in the expected format to train the model.
+This repository does not include any dataset; you must supply your own workbook to train the model.

--- a/attention_model.py
+++ b/attention_model.py
@@ -1,10 +1,11 @@
 import math
 import torch
 from torch import nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import Dataset, DataLoader, random_split
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
+from sklearn.metrics import r2_score
 
 
 class PositionalEncoding(nn.Module):
@@ -108,39 +109,84 @@ class ExcelRecipeDataset(Dataset):
         )
 
 
-def _generate_example_csv(path: str, num_samples=100, seq_len=4, num_targets=2, num_step_types=5):
-    rng = np.random.default_rng(0)
-    data = {}
-    for i in range(seq_len):
-        data[f"step_type_{i}"] = rng.integers(0, num_step_types, size=num_samples)
-        data[f"knob_{i}"] = rng.random(size=num_samples)
-    for t in range(num_targets):
-        data[f"target_{t}"] = rng.random(size=num_samples)
-    pd.DataFrame(data).to_csv(path, index=False)
+class MultiSheetRecipeDataset(Dataset):
+    """Dataset for workbooks where each sheet contains a recipe structure.
+
+    Columns beginning with ``X_`` define the sequential steps in that sheet. The
+    portion between the first and second underscore denotes the step type (e.g.
+    ``X_ME_Power``). Columns beginning with ``Y_`` are treated as targets. The
+    loader flattens each sheet into ``step_type_i`` and ``knob_i`` columns so
+    that all sheets can be concatenated into a single table.
+    """
+
+    def __init__(self, excel_path: str) -> None:
+        sheets = pd.read_excel(excel_path, sheet_name=None)
+
+        step_names: set[str] = set()
+        max_len = 0
+        processed: list[pd.DataFrame] = []
+
+        # First pass to gather step types and maximum sequence length
+        temp_frames = []
+        for df in sheets.values():
+            step_cols = [c for c in df.columns if c.startswith("X_")]
+            target_cols = [c for c in df.columns if c.startswith("Y_")]
+            order = step_cols
+            max_len = max(max_len, len(order))
+            step_names.update(col.split("_")[1] for col in order)
+            temp_frames.append((df, order, target_cols))
+
+        self.step_map = {name: idx for idx, name in enumerate(sorted(step_names))}
+
+        all_step_cols = [f"step_type_{i}" for i in range(max_len)]
+        all_knob_cols = [f"knob_{i}" for i in range(max_len)]
+
+        # Convert each sheet to unified layout
+        for df, order, tcols in temp_frames:
+            new_df = pd.DataFrame()
+            for i in range(max_len):
+                if i < len(order):
+                    orig = order[i]
+                    step_name = orig.split("_")[1]
+                    new_df[f"step_type_{i}"] = self.step_map[step_name]
+                    new_df[f"knob_{i}"] = df[orig].astype(float)
+                else:
+                    new_df[f"step_type_{i}"] = 0
+                    new_df[f"knob_{i}"] = 0.0
+            for col in tcols:
+                new_df[col] = df[col].astype(float)
+            processed.append(new_df)
+
+        # Ensure all frames share the same target columns
+        target_cols = sorted({c for _, _, tc in temp_frames for c in tc})
+        for df in processed:
+            for c in target_cols:
+                if c not in df.columns:
+                    df[c] = 0.0
+            df.sort_index(axis=1, inplace=True)
+
+        self.data = pd.concat(processed, ignore_index=True)
+        self.seq_len = max_len
+        self.step_cols = all_step_cols
+        self.knob_cols = all_knob_cols
+        self.target_cols = target_cols
+        self.num_step_types = len(self.step_map)
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        row = self.data.iloc[idx]
+        step_types = row[self.step_cols].to_numpy(dtype=np.int64)
+        knobs = row[self.knob_cols].to_numpy(dtype=np.float32)
+        targets = row[self.target_cols].to_numpy(dtype=np.float32)
+        return (
+            torch.from_numpy(step_types),
+            torch.from_numpy(knobs),
+            torch.from_numpy(targets),
+        )
 
 
-def _generate_example_excel(path: str) -> None:
-    """Create a toy Excel workbook with two recipe structures."""
-    rng = np.random.default_rng(0)
-    # first sheet has 4 steps
-    data_a = {}
-    for i in range(4):
-        data_a[f"step_type_{i}"] = rng.integers(0, 5, size=50)
-        data_a[f"knob_{i}"] = rng.random(size=50)
-    data_a["target_0"] = rng.random(size=50)
-    df_a = pd.DataFrame(data_a)
-
-    # second sheet has 3 steps
-    data_b = {}
-    for i in range(3):
-        data_b[f"step_type_{i}"] = rng.integers(0, 5, size=50)
-        data_b[f"knob_{i}"] = rng.random(size=50)
-    data_b["target_0"] = rng.random(size=50)
-    df_b = pd.DataFrame(data_b)
-
-    with pd.ExcelWriter(path) as writer:
-        df_a.to_excel(writer, sheet_name="ME_SL1_SL2_DF", index=False)
-        df_b.to_excel(writer, sheet_name="ME_SL1_DF", index=False)
 
 
 class AttentionModel(nn.Module):
@@ -205,74 +251,95 @@ def step_importance(weights: torch.Tensor) -> torch.Tensor:
     return weights.mean(0)
 
 
-def train_example():
-    csv_path = "example.csv"
-    seq_len = 4
-    num_step_types = 5
-    num_targets = 2
 
-    dataset = RecipeDataset(csv_path, seq_len=seq_len, num_step_types=num_step_types)
-    loader = DataLoader(dataset, batch_size=16, shuffle=True)
+def train_multisheet_excel(excel_path: str, epochs: int = 10) -> None:
+    """Train on a workbook containing multiple recipe structures."""
+    dataset = MultiSheetRecipeDataset(excel_path)
+    train_size = int(len(dataset) * 0.8)
+    test_size = len(dataset) - train_size
+    train_ds, test_ds = random_split(dataset, [train_size, test_size])
 
-
-    model = AttentionModel(num_step_types=num_step_types, d_model=32, nhead=4, num_targets=num_targets, seq_len=seq_len)
-    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
-    loss_fn = nn.MSELoss()
-
-    model.train()
-    for epoch in range(5):
-        for step_types, knobs, targets in loader:
-            optim.zero_grad()
-            preds = model(step_types, knobs)
-            loss = loss_fn(preds, targets)
-            loss.backward()
-            optim.step()
-        print(f"Epoch {epoch+1} loss: {loss.item():.4f}")
-
-
-    # visualize positional encodings
-    plot_positional_encoding(model.pos_encoder.pe[:seq_len])
-
-    # show attention weights for first batch
-    step_types, knobs, _ = next(iter(loader))
-    attn = model.attention_heatmap(step_types[0], knobs[0])
-    plot_attention_heatmap(attn)
-    print("Step importance:", step_importance(attn))
-
-
-def train_excel_example():
-    excel_path = "recipes.xlsx"
-    _generate_example_excel(excel_path)
-    dataset = ExcelRecipeDataset(excel_path)
-    loader = DataLoader(dataset, batch_size=16, shuffle=True)
+    train_loader = DataLoader(train_ds, batch_size=16, shuffle=True)
+    test_loader = DataLoader(test_ds, batch_size=16, shuffle=False)
 
     model = AttentionModel(
         num_step_types=dataset.num_step_types,
-        d_model=32,
+        d_model=64,
         nhead=4,
         num_targets=len(dataset.target_cols),
         seq_len=dataset.seq_len,
     )
+
     optim = torch.optim.Adam(model.parameters(), lr=1e-3)
     loss_fn = nn.MSELoss()
 
-    model.train()
-    for epoch in range(5):
-        for step_types, knobs, targets in loader:
+    for epoch in range(epochs):
+        model.train()
+        for step_types, knobs, targets in train_loader:
             optim.zero_grad()
             preds = model(step_types, knobs)
             loss = loss_fn(preds, targets)
             loss.backward()
             optim.step()
-        print(f"Epoch {epoch+1} loss: {loss.item():.4f}")
 
-    plot_positional_encoding(model.pos_encoder.pe[:dataset.seq_len])
-    step_types, knobs, _ = next(iter(loader))
-    attn = model.attention_heatmap(step_types[0], knobs[0])
+        # evaluate R2 on train and test sets
+        model.eval()
+        with torch.no_grad():
+            train_preds, train_tgts = [], []
+            for st, kb, tg in train_loader:
+                p = model(st, kb)
+                train_preds.append(p)
+                train_tgts.append(tg)
+            test_preds, test_tgts = [], []
+            for st, kb, tg in test_loader:
+                p = model(st, kb)
+                test_preds.append(p)
+                test_tgts.append(tg)
+        train_preds = torch.cat(train_preds).cpu().numpy()
+        train_tgts = torch.cat(train_tgts).cpu().numpy()
+        test_preds = torch.cat(test_preds).cpu().numpy()
+        test_tgts = torch.cat(test_tgts).cpu().numpy()
+
+        train_r2 = r2_score(train_tgts, train_preds, multioutput="variance_weighted")
+        test_r2 = r2_score(test_tgts, test_preds, multioutput="variance_weighted")
+        print(
+            f"Epoch {epoch+1}/{epochs} Loss {loss.item():.4f} Train R2 {train_r2:.3f} Test R2 {test_r2:.3f}"
+        )
+
+    # explainability utilities
+    plot_positional_encoding(model.pos_encoder.pe[: dataset.seq_len])
+    sample_steps, sample_knobs, sample_targets = next(iter(test_loader))
+    attn = model.attention_heatmap(sample_steps[0], sample_knobs[0])
     plot_attention_heatmap(attn)
-    print("Step importance:", step_importance(attn))
+
+    # show real vs predicted for a few recipes
+    with torch.no_grad():
+        preds = model(sample_steps, sample_knobs)
+    for i in range(min(3, len(sample_steps))):
+        print(
+            f"Recipe {i}: real={sample_targets[i].tolist()} pred={preds[i].tolist()}"
+        )
 
 
 if __name__ == "__main__":
-    train_excel_example()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Train the attention model on a recipe workbook"
+    )
+    parser.add_argument(
+        "workbook",
+        nargs="?",
+        default="recipes.xlsx",
+        help="Path to the Excel workbook with recipe sheets",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        help="Number of training epochs",
+    )
+    args, _ = parser.parse_known_args()
+
+    train_multisheet_excel(args.workbook, epochs=args.epochs)
 

--- a/etch_rate_model.py
+++ b/etch_rate_model.py
@@ -40,25 +40,6 @@ class EtchRateDataset(Dataset):
 
 
 
-def _generate_example_csv(
-    path: str,
-    num_samples: int = 100,
-    seq_len: int = 4,
-    num_targets: int = 1,
-    num_step_types: int = 5,
-    num_schemes: int = 3,
-    num_layouts: int = 2,
-):
-    rng = np.random.default_rng(0)
-    data = {}
-    for i in range(seq_len):
-        data[f"step_type_{i}"] = rng.integers(0, num_step_types, size=num_samples)
-        data[f"knob_{i}"] = rng.random(size=num_samples)
-    data["scheme_id"] = rng.integers(0, num_schemes, size=num_samples)
-    data["layout_id"] = rng.integers(0, num_layouts, size=num_samples)
-    for t in range(num_targets):
-        data[f"target_{t}"] = rng.random(size=num_samples)
-    pd.DataFrame(data).to_csv(path, index=False)
 
 
 
@@ -103,50 +84,3 @@ class EtchRateTransformer(nn.Module):
         return self.fc(enc.mean(dim=1))
 
 
-def train_etch_rate_example():
-    csv_path = "etch_example.csv"
-    seq_len = 5
-    num_step_types = 6
-    num_schemes = 3
-    num_layouts = 2
-    num_targets = 1
-
-
-    _generate_example_csv(
-        csv_path,
-        num_samples=200,
-        seq_len=seq_len,
-        num_targets=num_targets,
-        num_step_types=num_step_types,
-        num_schemes=num_schemes,
-        num_layouts=num_layouts,
-    )
-    
-    dataset = EtchRateDataset(csv_path, seq_len=seq_len)
-    loader = DataLoader(dataset, batch_size=16, shuffle=True)
-
-    model = EtchRateTransformer(
-        num_step_types=num_step_types,
-        num_schemes=num_schemes,
-        num_layouts=num_layouts,
-        d_model=32,
-        nhead=4,
-        num_targets=num_targets,
-        seq_len=seq_len,
-    )
-    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
-    loss_fn = nn.MSELoss()
-
-    model.train()
-    for epoch in range(5):
-        for step_types, knobs, scheme, layout, targets in loader:
-            optim.zero_grad()
-            preds = model(step_types, knobs, scheme, layout)
-            loss = loss_fn(preds, targets)
-            loss.backward()
-            optim.step()
-        print(f"Epoch {epoch+1} loss: {loss.item():.4f}")
-
-
-if __name__ == "__main__":
-    train_etch_rate_example()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 numpy
 matplotlib
 openpyxl
+scikit-learn


### PR DESCRIPTION
## Summary
- remove synthetic dataset generation and example train scripts
- add a CLI to `attention_model.py` that accepts a workbook path and epoch count
- update README usage instructions

## Testing
- `python -m py_compile attention_model.py etch_rate_model.py`
